### PR TITLE
Blackfin disasm: remove reduntant base16 prefixes

### DIFF
--- a/disas/bfin.c
+++ b/disas/bfin.c
@@ -1263,24 +1263,24 @@ decode_BRCC_0 (TIword iw0, bfd_vma pc, disassemble_info *outf)
 
   if (T == 1 && B == 1)
     {
-      OUTS (outf, "IF CC JUMP 0x");
+      OUTS (outf, "IF CC JUMP ");
       OUTS (outf, pcrel10 (offset));
       OUTS (outf, " (BP)");
     }
   else if (T == 0 && B == 1)
     {
-      OUTS (outf, "IF !CC JUMP 0x");
+      OUTS (outf, "IF !CC JUMP ");
       OUTS (outf, pcrel10 (offset));
       OUTS (outf, " (BP)");
     }
   else if (T == 1)
     {
-      OUTS (outf, "IF CC JUMP 0x");
+      OUTS (outf, "IF CC JUMP ");
       OUTS (outf, pcrel10 (offset));
     }
   else if (T == 0)
     {
-      OUTS (outf, "IF !CC JUMP 0x");
+      OUTS (outf, "IF !CC JUMP ");
       OUTS (outf, pcrel10 (offset));
     }
   else
@@ -1302,7 +1302,7 @@ decode_UJUMP_0 (TIword iw0, bfd_vma pc, disassemble_info *outf)
   if (priv->parallel)
     return 0;
 
-  OUTS (outf, "JUMP.S 0x");
+  OUTS (outf, "JUMP.S ");
   OUTS (outf, pcrel12 (offset));
   return 2;
 }
@@ -2574,9 +2574,9 @@ decode_LoopSetup_0 (TIword iw0, TIword iw1, bfd_vma pc, disassemble_info *outf)
   if (rop == 0)
     {
       OUTS (outf, "LSETUP");
-      OUTS (outf, "(0x");
+      OUTS (outf, "(");
       OUTS (outf, pcrel4 (soffset));
-      OUTS (outf, ", 0x");
+      OUTS (outf, ", ");
       OUTS (outf, lppcrel10 (eoffset));
       OUTS (outf, ") ");
       OUTS (outf, counters (c));
@@ -2584,9 +2584,9 @@ decode_LoopSetup_0 (TIword iw0, TIword iw1, bfd_vma pc, disassemble_info *outf)
   else if (rop == 1)
     {
       OUTS (outf, "LSETUP");
-      OUTS (outf, "(0x");
+      OUTS (outf, "(");
       OUTS (outf, pcrel4 (soffset));
-      OUTS (outf, ", 0x");
+      OUTS (outf, ", ");
       OUTS (outf, lppcrel10 (eoffset));
       OUTS (outf, ") ");
       OUTS (outf, counters (c));
@@ -2596,9 +2596,9 @@ decode_LoopSetup_0 (TIword iw0, TIword iw1, bfd_vma pc, disassemble_info *outf)
   else if (rop == 3)
     {
       OUTS (outf, "LSETUP");
-      OUTS (outf, "(0x");
+      OUTS (outf, "(");
       OUTS (outf, pcrel4 (soffset));
-      OUTS (outf, ", 0x");
+      OUTS (outf, ", ");
       OUTS (outf, lppcrel10 (eoffset));
       OUTS (outf, ") ");
       OUTS (outf, counters (c));
@@ -2724,13 +2724,13 @@ decode_LDIMMhalf_0 (TIword iw0, TIword iw1, disassemble_info *outf)
       if (*pval < 0xFFC00000 && grp == 1)
 	{
 	  OUTS (outf, regs (reg, grp));
-	  OUTS (outf, "=0x");
+	  OUTS (outf, "=");
 	  OUTS (outf, huimm32e (*pval));
 	}
       else
 	{
 	  OUTS (outf, regs (reg, grp));
-	  OUTS (outf, "=0x");
+	  OUTS (outf, "=");
 	  OUTS (outf, huimm32e (*pval));
 	  OUTS (outf, "(");
 	  OUTS (outf, imm32 (*pval));
@@ -2744,7 +2744,7 @@ decode_LDIMMhalf_0 (TIword iw0, TIword iw1, disassemble_info *outf)
     {
       OUTS (outf, ";\t\t/*\t\t");
       OUTS (outf, regs (reg, grp));
-      OUTS (outf, "=0x");
+      OUTS (outf, "=");
       OUTS (outf, huimm32e (*pval));
       OUTS (outf, "(");
       OUTS (outf, imm32 (*pval));
@@ -2771,9 +2771,9 @@ decode_CALLa_0 (TIword iw0, TIword iw1, bfd_vma pc, disassemble_info *outf)
     return 0;
 
   if (S == 1)
-    OUTS (outf, "CALL 0x");
+    OUTS (outf, "CALL ");
   else if (S == 0)
-    OUTS (outf, "JUMP.L 0x");
+    OUTS (outf, "JUMP.L ");
   else
     return 0;
 


### PR DESCRIPTION
Hi,
this commit would remove double '0x' prefixes from Blackfin disassembly output, like e.g.:
0xfff44e7e:  P2.H = 0xfffc;		/* ( -4)	P2=0x0xfffc3f58(-245928) */
0xfff44e82:  P2.L = 0x3f54;		/* (16212)	P2=0x0xfffc3f54(-245932) */
0xfff44e86:  CC = R0 == 0x0;
0xfff44e88:  IF CC JUMP 0x0xfff44e90;

would become to:
0xfff44e7e:  P2.H = 0xfffc;		/* ( -4)	P2=0xfffc3f58(-245928) */
0xfff44e82:  P2.L = 0x3f54;		/* (16212)	P2=0xfffc3f54(-245932) */
0xfff44e86:  CC = R0 == 0x0;
0xfff44e88:  IF CC JUMP 0xfff44e90;
